### PR TITLE
Improve error messages for regular expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Report error message from regexp.Compile if compilation fails #21
 
 ### Deprecated
 

--- a/error.go
+++ b/error.go
@@ -279,3 +279,10 @@ func raiseInvalidDuration(v value, err error) Error {
 func raiseValidation(ctx context, meta *Meta, err error) Error {
 	return raiseErr(err, messagePath(err, meta, err.Error(), ctx.path(".")))
 }
+
+func raiseInvalidRegexp(v value, err error) Error {
+	ctx := v.Context()
+	path := ctx.path(".")
+	message := fmt.Sprintf("Failed to compile regular expression with '%v'", err)
+	return raisePathErr(err, v.meta(), message, path)
+}

--- a/error_test.go
+++ b/error_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"path"
 	"reflect"
+	"regexp"
 	"testing"
 	"time"
 
@@ -31,6 +32,7 @@ func TestErrorMessages(t *testing.T) {
 	cNestedMeta.ctx = testNestedCtx
 
 	_, timeErr := time.ParseDuration("1 hour")
+	_, regexpErr := regexp.Compile(`[`)
 
 	tests := map[string]Error{
 		"duplicate_wo_meta":        raiseDuplicateKey(c, "test"),
@@ -57,6 +59,11 @@ func TestErrorMessages(t *testing.T) {
 			context{field: "timeout"}, nil, ""), timeErr),
 		"invalid_duration_w_meta": raiseInvalidDuration(newString(
 			context{field: "timeout"}, testMeta, ""), timeErr),
+
+		"invalid_regexp_wo_meta": raiseInvalidRegexp(newString(
+			context{field: "regex"}, nil, ""), regexpErr),
+		"invalid_regexp_w_meta": raiseInvalidRegexp(newString(
+			context{field: "regex"}, testMeta, ""), regexpErr),
 
 		"invalid_type_top_level": raiseInvalidTopLevelType(""),
 

--- a/reify.go
+++ b/reify.go
@@ -183,12 +183,7 @@ func reifyValue(
 	if baseType.Kind() == reflect.Struct {
 		sub, err := val.toConfig()
 		if err != nil {
-			// try primitive
-			if v, check := reifyPrimitive(opts, val, t, baseType); check == nil {
-				return v, nil
-			}
-
-			return reflect.Value{}, raiseExpectedObject(val)
+			return reifyPrimitive(opts, val, t, baseType)
 		}
 
 		newSt := reflect.New(baseType)
@@ -490,7 +485,7 @@ func reifyRegexp(
 
 	r, err := regexp.Compile(s)
 	if err != nil {
-		return reflect.Value{}, raiseConversion(val, err, "regex")
+		return reflect.Value{}, raiseInvalidRegexp(val, err)
 	}
 	return reflect.ValueOf(r).Elem(), nil
 }

--- a/testdata/error/message/invalid_regexp_w_meta.golden
+++ b/testdata/error/message/invalid_regexp_w_meta.golden
@@ -1,0 +1,1 @@
+Failed to compile regular expression with 'error parsing regexp: missing closing ]: `[`' accessing 'regex' (source:'test.source')

--- a/testdata/error/message/invalid_regexp_wo_meta.golden
+++ b/testdata/error/message/invalid_regexp_wo_meta.golden
@@ -1,0 +1,1 @@
+Failed to compile regular expression with 'error parsing regexp: missing closing ]: `[`' accessing 'regex'


### PR DESCRIPTION
Improve regexp error messages by including the reason compilation failed