### PR TITLE
Improve/fix required/nonzero validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Handle empty slices, strings, regular expression by nonzero,required validation tags #20, #23
 
 ## [0.2.0]
 

--- a/error.go
+++ b/error.go
@@ -75,6 +75,8 @@ var (
 	ErrZeroValue = errors.New("zero value")
 
 	ErrRequired = errors.New("missing required field")
+
+	ErrEmpty = errors.New("empty field")
 )
 
 // error classes

--- a/reify.go
+++ b/reify.go
@@ -140,7 +140,8 @@ func reifyGetField(
 	if err != nil {
 		return err
 	}
-	if value == nil {
+
+	if _, ok := value.(*cfgNil); value == nil || ok {
 		if err := runValidators(nil, opts.validators); err != nil {
 			return raiseValidation(cfg.ctx, cfg.metadata, err)
 		}
@@ -151,6 +152,7 @@ func reifyGetField(
 	if err != nil {
 		return err
 	}
+
 	to.Set(v)
 	return nil
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -2,6 +2,7 @@ package ucfg
 
 import (
 	"errors"
+	"regexp"
 	"testing"
 	"time"
 
@@ -227,39 +228,164 @@ func TestValidationFail(t *testing.T) {
 }
 
 func TestValidateRequiredFailing(t *testing.T) {
-	tests := []interface{}{
-		&struct {
+	c, _ := NewFrom(node{
+		"b": "",
+		"c": nil,
+		"d": []string{},
+	})
+
+	tests := []struct {
+		err    error
+		config interface{}
+	}{
+		// Access missing field 'a'
+		{ErrRequired, &struct {
 			A *int `validate:"required"`
-		}{},
-
-		&struct {
+		}{}},
+		{ErrRequired, &struct {
 			A int `validate:"required"`
-		}{},
-
-		&struct {
+		}{}},
+		{ErrRequired, &struct {
 			A string `validate:"required"`
-		}{},
-
-		&struct {
+		}{}},
+		{ErrRequired, &struct {
 			A []string `validate:"required"`
-		}{},
-
-		&struct {
+		}{}},
+		{ErrRequired, &struct {
 			A time.Duration `validate:"required"`
-		}{},
+		}{}},
+
+		// Access empty string field "b"
+		{ErrEmpty, &struct {
+			B string `validate:"required"`
+		}{}},
+		{ErrEmpty, &struct {
+			B *string `validate:"required"`
+		}{}},
+		{ErrEmpty, &struct {
+			B *regexp.Regexp `validate:"required"`
+		}{}},
+
+		// Access nil value "c"
+		{ErrRequired, &struct {
+			C *int `validate:"required"`
+		}{}},
+		{ErrRequired, &struct {
+			C int `validate:"required"`
+		}{}},
+		{ErrRequired, &struct {
+			C string `validate:"required"`
+		}{}},
+		{ErrRequired, &struct {
+			C []string `validate:"required"`
+		}{}},
+		{ErrRequired, &struct {
+			C time.Duration `validate:"required"`
+		}{}},
+
+		// Check empty []string field 'd'
+		{ErrEmpty, &struct {
+			D []string `validate:"required"`
+		}{}},
 	}
 
-	c := New()
 	for i, test := range tests {
-		t.Logf("Test config (%v): %#v", i, test)
+		t.Logf("Test config (%v): %#v => %v", i, test.config, test.err)
 
-		err := c.Unpack(test)
+		err := c.Unpack(test.config)
 		if err == nil {
 			t.Error("Expected error")
 			continue
 		}
 
+		t.Logf("Unpack returned error: %v", err)
 		err = err.(Error).Reason()
-		assert.Equal(t, ErrRequired, err)
+		assert.Equal(t, test.err, err)
+	}
+}
+
+func TestValidateNonzeroFailing(t *testing.T) {
+	c, _ := NewFrom(node{
+		"i": 0,
+		"s": "",
+		"a": []int{},
+	})
+
+	tests := []struct {
+		err    error
+		config interface{}
+	}{
+		// test integer types accessing 'i'
+		{ErrZeroValue, &struct {
+			I int `validate:"nonzero"`
+		}{}},
+		{ErrZeroValue, &struct {
+			I int8 `validate:"nonzero"`
+		}{}},
+		{ErrZeroValue, &struct {
+			I int16 `validate:"nonzero"`
+		}{}},
+		{ErrZeroValue, &struct {
+			I int32 `validate:"nonzero"`
+		}{}},
+		{ErrZeroValue, &struct {
+			I int64 `validate:"nonzero"`
+		}{}},
+		{ErrZeroValue, &struct {
+			I uint `validate:"nonzero"`
+		}{}},
+		{ErrZeroValue, &struct {
+			I uint8 `validate:"nonzero"`
+		}{}},
+		{ErrZeroValue, &struct {
+			I uint16 `validate:"nonzero"`
+		}{}},
+		{ErrZeroValue, &struct {
+			I uint32 `validate:"nonzero"`
+		}{}},
+		{ErrZeroValue, &struct {
+			I uint64 `validate:"nonzero"`
+		}{}},
+
+		// test float types accessing 'i'
+		{ErrZeroValue, &struct {
+			I float32 `validate:"nonzero"`
+		}{}},
+		{ErrZeroValue, &struct {
+			I float64 `validate:"nonzero"`
+		}{}},
+
+		// test string types accessing 's'
+		{ErrEmpty, &struct {
+			S string `validate:"nonzero"`
+		}{}},
+		{ErrEmpty, &struct {
+			S *string `validate:"nonzero"`
+		}{}},
+		{ErrEmpty, &struct {
+			S *regexp.Regexp `validate:"nonzero"`
+		}{}},
+
+		// test array type accessing 'a'
+		{ErrEmpty, &struct {
+			A []int `validate:"nonzero"`
+		}{}},
+		{ErrEmpty, &struct {
+			A []uint8 `validate:"nonzero"`
+		}{}},
+	}
+
+	for i, test := range tests {
+		t.Logf("Test config (%v): %#v => %v", i, test.config, test.err)
+
+		err := c.Unpack(test.config)
+		if err == nil {
+			t.Error("Expected error")
+			continue
+		}
+
+		t.Logf("Unpack returned error: %v", err)
+		err = err.(Error).Reason()
+		assert.Equal(t, test.err, err)
 	}
 }


### PR DESCRIPTION
Check slices, strings and regular expression being empty.

updates `required` to check:
- string being not ""   intending: require requires string to be present and not empty
- pointers being set intending: pointers to struct must be set
- length of slice > 0 intending: array must be present at least one entry is required.

update nonzero to check:
- string being not "" intending: if present it must not be empty
- length of slice > 0: if array/slice present it must not be empty.

Closes #20 