### PR TITLE
Initial support for variable expansion

### DIFF
--- a/error.go
+++ b/error.go
@@ -182,7 +182,8 @@ func raiseMissingArr(ctx context, meta *Meta, idx int) Error {
 func raiseIndexOutOfBounds(value value, idx int) Error {
 	reason := ErrIndexOutOfRange
 	ctx := value.Context()
-	message := fmt.Sprintf("index '%v' out of range (length=%v)", idx, value.Len())
+	len, _ := value.Len()
+	message := fmt.Sprintf("index '%v' out of range (length=%v)", idx, len)
 	return raisePathErr(reason, value.meta(), message, ctx.path("."))
 }
 
@@ -240,9 +241,11 @@ func raisePointerRequired(v reflect.Value) Error {
 	return raiseCritical(ErrPointerRequired, "")
 }
 
-func raiseToTypeNotSupported(v value, t reflect.Type) Error {
+func raiseToTypeNotSupported(v value, goT reflect.Type) Error {
 	reason := ErrTypeMismatch
-	message := fmt.Sprintf("value of type '%v' not convertible into unsupported go type '%v'", v.typeName(), t)
+	t, _ := v.typ()
+	message := fmt.Sprintf("value of type '%v' not convertible into unsupported go type '%v'",
+		t.name, goT)
 	ctx := v.Context()
 
 	return raiseCritical(reason, messagePath(reason, v.meta(), message, ctx.path(".")))
@@ -259,15 +262,17 @@ func raiseArraySize(ctx context, meta *Meta, n int, to int) Error {
 func raiseConversion(v value, err error, to string) Error {
 	ctx := v.Context()
 	path := ctx.path(".")
-	message := fmt.Sprintf("can not convert '%v' into '%v'", v.typeName(), to)
+	t, _ := v.typ()
+	message := fmt.Sprintf("can not convert '%v' into '%v'", t.name, to)
 	return raisePathErr(err, v.meta(), message, path)
 }
 
 func raiseExpectedObject(v value) Error {
 	ctx := v.Context()
 	path := ctx.path(".")
+	t, _ := v.typ()
 	message := fmt.Sprintf("required 'object', but found '%v' in field '%v'",
-		v.typeName(), path)
+		t.name, path)
 
 	return raiseErr(ErrExpectedObject, messageMeta(message, v.meta()))
 }

--- a/error.go
+++ b/error.go
@@ -293,3 +293,8 @@ func raiseInvalidRegexp(v value, err error) Error {
 	message := fmt.Sprintf("Failed to compile regular expression with '%v'", err)
 	return raisePathErr(err, v.meta(), message, path)
 }
+
+func raiseParseSplice(ctx context, meta *Meta, err error) Error {
+	message := fmt.Sprintf("%v parsing splice", err)
+	return raisePathErr(err, meta, message, ctx.path("."))
+}

--- a/error_test.go
+++ b/error_test.go
@@ -161,6 +161,9 @@ func TestErrorMessages(t *testing.T) {
 			testNestedCtx, nil, errors.New("invalid value")),
 		"validation_nested_w_meta": raiseValidation(
 			testNestedCtx, testMeta, errors.New("invalid value")),
+
+		"parse_splice_w_meta": raiseParseSplice(
+			testNestedCtx, nil, errUnterminatedBrace),
 	}
 
 	for name, result := range tests {

--- a/getset.go
+++ b/getset.go
@@ -15,7 +15,7 @@ func convertErr(v value, err error, to string) Error {
 // of elements in list
 func (c *Config) CountField(name string) (int, error) {
 	if v, ok := c.fields.fields[name]; ok {
-		return v.Len(), nil
+		return v.Len()
 	}
 	return -1, raiseMissing(c, name)
 }

--- a/opts.go
+++ b/opts.go
@@ -7,6 +7,7 @@ type options struct {
 	validatorTag string
 	pathSep      string
 	meta         *Meta
+	varexp       bool
 }
 
 func StructTag(tag string) Option {
@@ -31,6 +32,10 @@ func MetaData(meta Meta) Option {
 	return func(o *options) {
 		o.meta = &meta
 	}
+}
+
+var VarExp Option = func(o *options) {
+	o.varexp = true
 }
 
 func makeOptions(opts []Option) options {

--- a/testdata/error/message/parse_splice_w_meta.golden
+++ b/testdata/error/message/parse_splice_w_meta.golden
@@ -1,0 +1,1 @@
+unterminated brace parsing splice accessing 'nested'

--- a/types.go
+++ b/types.go
@@ -7,6 +7,8 @@ import (
 )
 
 type value interface {
+	typ() (typeInfo, error)
+
 	cpy(c context) value
 
 	Context() context
@@ -15,13 +17,10 @@ type value interface {
 	meta() *Meta
 	setMeta(m *Meta)
 
-	Len() int
+	Len() (int, error)
 
-	reflect() reflect.Value
-	typ() reflect.Type
-	reify() interface{}
-
-	typeName() string
+	reflect() (reflect.Value, error)
+	reify() (interface{}, error)
 
 	toBool() (bool, error)
 	toString() (string, error)
@@ -29,6 +28,11 @@ type value interface {
 	toUint() (uint64, error)
 	toFloat() (float64, error)
 	toConfig() (*Config, error)
+}
+
+type typeInfo struct {
+	name   string
+	gotype reflect.Type
 }
 
 type context struct {
@@ -83,6 +87,17 @@ func (c *context) empty() bool {
 	return c.parent == nil
 }
 
+func (c *context) getParent() *Config {
+	if c.parent == nil {
+		return nil
+	}
+
+	if cfg, ok := c.parent.(cfgSub); ok {
+		return cfg.c
+	}
+	return nil
+}
+
 func (c *context) path(sep string) string {
 	if c.field == "" {
 		return ""
@@ -129,7 +144,7 @@ func (p *cfgPrimitive) Context() context        { return p.ctx }
 func (p *cfgPrimitive) SetContext(c context)    { p.ctx = c }
 func (p *cfgPrimitive) meta() *Meta             { return p.metadata }
 func (p *cfgPrimitive) setMeta(m *Meta)         { p.metadata = m }
-func (cfgPrimitive) Len() int                   { return 1 }
+func (cfgPrimitive) Len() (int, error)          { return 1, nil }
 func (cfgPrimitive) toBool() (bool, error)      { return false, ErrTypeMismatch }
 func (cfgPrimitive) toString() (string, error)  { return "", ErrTypeMismatch }
 func (cfgPrimitive) toInt() (int64, error)      { return 0, ErrTypeMismatch }
@@ -137,40 +152,20 @@ func (cfgPrimitive) toUint() (uint64, error)    { return 0, ErrTypeMismatch }
 func (cfgPrimitive) toFloat() (float64, error)  { return 0, ErrTypeMismatch }
 func (cfgPrimitive) toConfig() (*Config, error) { return nil, ErrTypeMismatch }
 
-/*
-func (cfgArray) typeName() string          { return "array" }
-func (c *cfgArray) Len() int               { return len(c.arr) }
-func (c *cfgArray) reflect() reflect.Value { return reflect.ValueOf(c.arr) }
-func (cfgArray) typ() reflect.Type         { return tInterfaceArray }
+func (c *cfgNil) cpy(ctx context) value     { return &cfgNil{cfgPrimitive{ctx, c.metadata}} }
+func (*cfgNil) Len() (int, error)           { return 0, nil }
+func (*cfgNil) toString() (string, error)   { return "null", nil }
+func (*cfgNil) toInt() (int64, error)       { return 0, ErrTypeMismatch }
+func (*cfgNil) toUint() (uint64, error)     { return 0, ErrTypeMismatch }
+func (*cfgNil) toFloat() (float64, error)   { return 0, ErrTypeMismatch }
+func (*cfgNil) reify() (interface{}, error) { return nil, nil }
+func (*cfgNil) typ() (typeInfo, error)      { return typeInfo{"any", reflect.PtrTo(tConfig)}, nil }
+func (c *cfgNil) meta() *Meta               { return c.metadata }
+func (c *cfgNil) setMeta(m *Meta)           { c.metadata = m }
 
-func (c *cfgArray) cpy(ctx context) value {
-	return &cfgArray{cfgPrimitive{ctx, c.meta()}, c.arr}
-}
-
-func (c *cfgArray) reify() interface{} {
-	r := make([]interface{}, len(c.arr))
-	for i, v := range c.arr {
-		r[i] = v.reify()
-	}
-	return r
-}
-*/
-
-func (c *cfgNil) cpy(ctx context) value   { return &cfgNil{cfgPrimitive{ctx, c.metadata}} }
-func (*cfgNil) Len() int                  { return 0 }
-func (*cfgNil) typeName() string          { return "any" }
-func (*cfgNil) toString() (string, error) { return "null", nil }
-func (*cfgNil) toInt() (int64, error)     { return 0, ErrTypeMismatch }
-func (*cfgNil) toUint() (uint64, error)   { return 0, ErrTypeMismatch }
-func (*cfgNil) toFloat() (float64, error) { return 0, ErrTypeMismatch }
-func (*cfgNil) reify() interface{}        { return nil }
-func (*cfgNil) typ() reflect.Type         { return reflect.PtrTo(tConfig) }
-func (c *cfgNil) meta() *Meta             { return c.metadata }
-func (c *cfgNil) setMeta(m *Meta)         { c.metadata = m }
-
-func (c *cfgNil) reflect() reflect.Value {
+func (c *cfgNil) reflect() (reflect.Value, error) {
 	cfg, _ := c.toConfig()
-	return reflect.ValueOf(cfg)
+	return reflect.ValueOf(cfg), nil
 }
 
 func (c *cfgNil) toConfig() (*Config, error) {
@@ -179,21 +174,19 @@ func (c *cfgNil) toConfig() (*Config, error) {
 	return n, nil
 }
 
-func (c *cfgBool) cpy(ctx context) value     { return newBool(ctx, c.meta(), c.b) }
-func (*cfgBool) typeName() string            { return "bool" }
-func (c *cfgBool) toBool() (bool, error)     { return c.b, nil }
-func (c *cfgBool) reflect() reflect.Value    { return reflect.ValueOf(c.b) }
-func (c *cfgBool) reify() interface{}        { return c.b }
-func (c *cfgBool) toString() (string, error) { return fmt.Sprintf("%t", c.b), nil }
-func (c *cfgBool) typ() reflect.Type         { return tBool }
+func (c *cfgBool) cpy(ctx context) value           { return newBool(ctx, c.meta(), c.b) }
+func (c *cfgBool) toBool() (bool, error)           { return c.b, nil }
+func (c *cfgBool) reflect() (reflect.Value, error) { return reflect.ValueOf(c.b), nil }
+func (c *cfgBool) reify() (interface{}, error)     { return c.b, nil }
+func (c *cfgBool) toString() (string, error)       { return fmt.Sprintf("%t", c.b), nil }
+func (c *cfgBool) typ() (typeInfo, error)          { return typeInfo{"bool", tBool}, nil }
 
-func (c *cfgInt) cpy(ctx context) value     { return newInt(ctx, c.meta(), c.i) }
-func (*cfgInt) typeName() string            { return "int" }
-func (c *cfgInt) toInt() (int64, error)     { return c.i, nil }
-func (c *cfgInt) reflect() reflect.Value    { return reflect.ValueOf(c.i) }
-func (c *cfgInt) reify() interface{}        { return c.i }
-func (c *cfgInt) toString() (string, error) { return fmt.Sprintf("%d", c.i), nil }
-func (c *cfgInt) typ() reflect.Type         { return tInt64 }
+func (c *cfgInt) cpy(ctx context) value           { return newInt(ctx, c.meta(), c.i) }
+func (c *cfgInt) toInt() (int64, error)           { return c.i, nil }
+func (c *cfgInt) reflect() (reflect.Value, error) { return reflect.ValueOf(c.i), nil }
+func (c *cfgInt) reify() (interface{}, error)     { return c.i, nil }
+func (c *cfgInt) toString() (string, error)       { return fmt.Sprintf("%d", c.i), nil }
+func (c *cfgInt) typ() (typeInfo, error)          { return typeInfo{"int", tInt64}, nil }
 func (c *cfgInt) toUint() (uint64, error) {
 	if c.i < 0 {
 		return 0, ErrNegative
@@ -201,13 +194,12 @@ func (c *cfgInt) toUint() (uint64, error) {
 	return uint64(c.i), nil
 }
 
-func (c *cfgUint) cpy(ctx context) value     { return newUint(ctx, c.meta(), c.u) }
-func (c *cfgUint) typeName() string          { return "uint" }
-func (c *cfgUint) reflect() reflect.Value    { return reflect.ValueOf(c.u) }
-func (c *cfgUint) reify() interface{}        { return c.u }
-func (c *cfgUint) toString() (string, error) { return fmt.Sprintf("%d", c.u), nil }
-func (c *cfgUint) typ() reflect.Type         { return tUint64 }
-func (c *cfgUint) toUint() (uint64, error)   { return c.u, nil }
+func (c *cfgUint) cpy(ctx context) value           { return newUint(ctx, c.meta(), c.u) }
+func (c *cfgUint) reflect() (reflect.Value, error) { return reflect.ValueOf(c.u), nil }
+func (c *cfgUint) reify() (interface{}, error)     { return c.u, nil }
+func (c *cfgUint) toString() (string, error)       { return fmt.Sprintf("%d", c.u), nil }
+func (c *cfgUint) typ() (typeInfo, error)          { return typeInfo{"uint", tUint64}, nil }
+func (c *cfgUint) toUint() (uint64, error)         { return c.u, nil }
 func (c *cfgUint) toInt() (int64, error) {
 	if c.u > math.MaxInt64 {
 		return 0, ErrOverflow
@@ -215,13 +207,12 @@ func (c *cfgUint) toInt() (int64, error) {
 	return int64(c.u), nil
 }
 
-func (c *cfgFloat) cpy(ctx context) value     { return newFloat(ctx, c.meta(), c.f) }
-func (*cfgFloat) typeName() string            { return "float" }
-func (c *cfgFloat) toFloat() (float64, error) { return c.f, nil }
-func (c *cfgFloat) reflect() reflect.Value    { return reflect.ValueOf(c.f) }
-func (c *cfgFloat) reify() interface{}        { return c.f }
-func (c *cfgFloat) toString() (string, error) { return fmt.Sprintf("%v", c.f), nil }
-func (c *cfgFloat) typ() reflect.Type         { return tFloat64 }
+func (c *cfgFloat) cpy(ctx context) value           { return newFloat(ctx, c.meta(), c.f) }
+func (c *cfgFloat) toFloat() (float64, error)       { return c.f, nil }
+func (c *cfgFloat) reflect() (reflect.Value, error) { return reflect.ValueOf(c.f), nil }
+func (c *cfgFloat) reify() (interface{}, error)     { return c.f, nil }
+func (c *cfgFloat) toString() (string, error)       { return fmt.Sprintf("%v", c.f), nil }
+func (c *cfgFloat) typ() (typeInfo, error)          { return typeInfo{"float", tFloat64}, nil }
 
 func (c *cfgFloat) toUint() (uint64, error) {
 	if c.f < 0 {
@@ -240,26 +231,24 @@ func (c *cfgFloat) toInt() (int64, error) {
 	return int64(c.f), nil
 }
 
-func (c *cfgString) cpy(ctx context) value     { return newString(ctx, c.meta(), c.s) }
-func (*cfgString) typeName() string            { return "string" }
-func (c *cfgString) toString() (string, error) { return c.s, nil }
-func (c *cfgString) reflect() reflect.Value    { return reflect.ValueOf(c.s) }
-func (c *cfgString) reify() interface{}        { return c.s }
-func (c *cfgString) typ() reflect.Type         { return tString }
+func (c *cfgString) cpy(ctx context) value           { return newString(ctx, c.meta(), c.s) }
+func (c *cfgString) toString() (string, error)       { return c.s, nil }
+func (c *cfgString) reflect() (reflect.Value, error) { return reflect.ValueOf(c.s), nil }
+func (c *cfgString) reify() (interface{}, error)     { return c.s, nil }
+func (c *cfgString) typ() (typeInfo, error)          { return typeInfo{"string", tString}, nil }
 
-func (cfgSub) Len() int                     { return 1 }
-func (cfgSub) typeName() string             { return "object" }
-func (c cfgSub) Context() context           { return c.c.ctx }
-func (cfgSub) toBool() (bool, error)        { return false, ErrTypeMismatch }
-func (cfgSub) toString() (string, error)    { return "", ErrTypeMismatch }
-func (cfgSub) toInt() (int64, error)        { return 0, ErrTypeMismatch }
-func (cfgSub) toUint() (uint64, error)      { return 0, ErrTypeMismatch }
-func (cfgSub) toFloat() (float64, error)    { return 0, ErrTypeMismatch }
-func (c cfgSub) toConfig() (*Config, error) { return c.c, nil }
-func (cfgSub) typ() reflect.Type            { return reflect.PtrTo(tConfig) }
-func (c cfgSub) reflect() reflect.Value     { return reflect.ValueOf(c.c) }
-func (c cfgSub) meta() *Meta                { return c.c.metadata }
-func (c cfgSub) setMeta(m *Meta)            { c.c.metadata = m }
+func (cfgSub) Len() (int, error)                 { return 1, nil }
+func (c cfgSub) Context() context                { return c.c.ctx }
+func (cfgSub) toBool() (bool, error)             { return false, ErrTypeMismatch }
+func (cfgSub) toString() (string, error)         { return "", ErrTypeMismatch }
+func (cfgSub) toInt() (int64, error)             { return 0, ErrTypeMismatch }
+func (cfgSub) toUint() (uint64, error)           { return 0, ErrTypeMismatch }
+func (cfgSub) toFloat() (float64, error)         { return 0, ErrTypeMismatch }
+func (c cfgSub) toConfig() (*Config, error)      { return c.c, nil }
+func (cfgSub) typ() (typeInfo, error)            { return typeInfo{"object", reflect.PtrTo(tConfig)}, nil }
+func (c cfgSub) reflect() (reflect.Value, error) { return reflect.ValueOf(c.c), nil }
+func (c cfgSub) meta() *Meta                     { return c.c.metadata }
+func (c cfgSub) setMeta(m *Meta)                 { c.c.metadata = m }
 
 func (c cfgSub) cpy(ctx context) value {
 	return cfgSub{
@@ -278,33 +267,46 @@ func (c cfgSub) SetContext(ctx context) {
 	}
 }
 
-func (c cfgSub) reify() interface{} {
+func (c cfgSub) reify() (interface{}, error) {
 	fields := c.c.fields.fields
 	arr := c.c.fields.arr
 
 	switch {
 	case len(fields) == 0 && len(arr) == 0:
-		return nil
+		return nil, nil
 	case len(fields) > 0 && len(arr) == 0:
 		m := make(map[string]interface{})
 		for k, v := range c.c.fields.fields {
-			m[k] = v.reify()
+			var err error
+			if m[k], err = v.reify(); err != nil {
+				return nil, err
+			}
 		}
-		return m
+		return m, nil
 	case len(fields) == 0 && len(arr) > 0:
 		m := make([]interface{}, len(arr))
 		for i, v := range arr {
-			m[i] = v.reify()
+			var err error
+			if m[i], err = v.reify(); err != nil {
+				return nil, err
+			}
 		}
-		return m
+		return m, nil
 	default:
 		m := make(map[string]interface{})
 		for k, v := range c.c.fields.fields {
-			m[k] = v.reify()
+			var err error
+			if m[k], err = v.reify(); err != nil {
+				return nil, err
+			}
 		}
 		for i, v := range arr {
-			m[fmt.Sprintf("%d", i)] = v.reify()
+			var err error
+			m[fmt.Sprintf("%d", i)], err = v.reify()
+			if err != nil {
+				return nil, err
+			}
 		}
-		return m
+		return m, nil
 	}
 }

--- a/variables.go
+++ b/variables.go
@@ -1,0 +1,125 @@
+package ucfg
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+)
+
+type reference struct {
+	path cfgPath
+}
+
+type splice struct {
+	pieces []splicePiece
+}
+
+type splicePiece interface {
+	piece(cfg *Config) (string, error)
+}
+
+type stringPiece string
+
+var (
+	errUnterminatedBrace = errors.New("unterminated brace")
+	errInvalidType       = errors.New("invalid type")
+)
+
+func newReference(p cfgPath) *reference {
+	return &reference{p}
+}
+
+func (r *reference) resolve(cfg *Config) (value, error) {
+	root := cfgRoot(cfg)
+	if root == nil {
+		return nil, ErrMissing
+	}
+	return r.path.GetValue(root)
+}
+
+func (r *reference) piece(cfg *Config) (string, error) {
+	v, err := r.resolve(cfg)
+	if err != nil {
+		return "", err
+	}
+	return v.toString()
+}
+
+func (s stringPiece) piece(cfg *Config) (string, error) {
+	return string(s), nil
+}
+
+func (s *splice) eval(cfg *Config) (string, error) {
+	buf := bytes.NewBuffer(nil)
+	for _, p := range s.pieces {
+		s, err := p.piece(cfg)
+		if err != nil {
+			return "", err
+		}
+		buf.WriteString(s)
+	}
+	return buf.String(), nil
+}
+
+func cfgRoot(cfg *Config) *Config {
+	if cfg == nil {
+		return nil
+	}
+
+	for {
+		p := cfg.Parent()
+		if p == nil {
+			return cfg
+		}
+
+		cfg = p
+	}
+}
+
+func parseSplice(in, pathSep string) ([]splicePiece, error) {
+	var pieces []splicePiece
+	content := in
+	off := 0
+	for len(content) > 0 {
+		idx := strings.Index(content[off:], "${")
+		if idx < 0 {
+			pieces = append(pieces, stringPiece(content))
+			break
+		}
+
+		idx += off
+		off = idx + 2
+		// if '$${', ignore and continue parsing
+		if idx > 0 && content[idx-1] == '$' {
+			continue
+		}
+
+		// found start of variable, store passed content into pieces
+		str := content[:idx]
+		if str != "" {
+			pieces = append(pieces, stringPiece(str))
+		}
+
+		// find variable end:
+		end := strings.Index(content[off:], "}")
+		if end < 0 {
+			// err, found variable start without end
+			return nil, errUnterminatedBrace
+		}
+
+		// get variable content indices + update offset
+		start := off
+		end += off
+		off = end + 1
+
+		// parse variable
+		path := parsePath(content[start:end], pathSep)
+		pieces = append(pieces, newReference(path))
+
+		// reset string and parse offset
+		content = content[off:]
+		off = 0
+	}
+
+	return pieces, nil
+}


### PR DESCRIPTION
When merging configurations, content can be referenced by absolute path.
When building references there is a difference between plain references and
splices.

A splice is one or multiple references combined with plain strings
lazily composed into a string when reading the configuration its value. Spliced
values can be parsed into primitive types (bool, int, float, string) only.

References, do reference (late binding) configuration values by absolute path
including nested configurations.

If only one expansion is given for a configuration value, a reference will be
established.